### PR TITLE
Fix wget opt bug for resolvers file downloading @dnscrypt-proxy_resol…

### DIFF
--- a/files/dnscrypt-proxy_resolvers.init
+++ b/files/dnscrypt-proxy_resolvers.init
@@ -43,7 +43,7 @@ cache_file() {
     local tmpf="/tmp/dnscrypt_${cdl##*/}.dl"
     local line
     [ ! -f "$fn" ] && {
-        wget -q --no-check-certificate -t 3 -O "$tmpf" "$cdl"
+        wget -q --no-check-certificate -T 3 -O "$tmpf" "$cdl"
         [ $? -eq 0 ] || return
         line=$(cat "$tmpf" | wc -l)
         [ $line -gt 1 ] || return


### PR DESCRIPTION
…vers.init

the correct form of "wget -t <num> ..." should be
1. wget -T <num>
2. wget --timout=<num>